### PR TITLE
feat(device): per-device layout, image rotation, and button filtering

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     DEVICES, TOKENS,
-    mappings::{COL_COUNT, CandidateDevice, ENCODER_COUNT, KEY_COUNT, Kind, ROW_COUNT},
+    mappings::{CandidateDevice, Kind},
 };
 
 /// Initializes a device and listens for events
@@ -45,9 +45,9 @@ pub async fn device_task(candidate: CandidateDevice, token: CancellationToken) {
             .register_device(
                 candidate.id.clone(),
                 candidate.kind.human_name(),
-                ROW_COUNT as u8,
-                COL_COUNT as u8,
-                ENCODER_COUNT as u8,
+                candidate.kind.row_count() as u8,
+                candidate.kind.col_count() as u8,
+                candidate.kind.encoder_count() as u8,
                 0,
             )
             .await
@@ -101,8 +101,8 @@ pub async fn connect(candidate: &CandidateDevice) -> Result<Device, MirajazzErro
     let result = Device::connect(
         &candidate.dev,
         candidate.kind.protocol_version(),
-        KEY_COUNT,
-        ENCODER_COUNT,
+        candidate.kind.key_count(),
+        candidate.kind.encoder_count(),
     )
     .await;
 
@@ -151,9 +151,15 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
             let id = candidate.id.clone();
 
             if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
+                let key_count = candidate.kind.key_count() as u8;
                 match update {
-                    DeviceStateUpdate::ButtonDown(key) => outbound.key_down(id, key).await.unwrap(),
-                    DeviceStateUpdate::ButtonUp(key) => outbound.key_up(id, key).await.unwrap(),
+                    DeviceStateUpdate::ButtonDown(key) if key < key_count => {
+                        outbound.key_down(id, key).await.unwrap();
+                    }
+                    DeviceStateUpdate::ButtonUp(key) if key < key_count => {
+                        outbound.key_up(id, key).await.unwrap();
+                    }
+                    DeviceStateUpdate::ButtonDown(_) | DeviceStateUpdate::ButtonUp(_) => {}
                     DeviceStateUpdate::EncoderDown(encoder) => {
                         outbound.encoder_down(id, encoder).await.unwrap();
                     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -151,15 +151,13 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
             let id = candidate.id.clone();
 
             if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
-                let key_count = candidate.kind.key_count() as u8;
                 match update {
-                    DeviceStateUpdate::ButtonDown(key) if key < key_count => {
+                    DeviceStateUpdate::ButtonDown(key) => {
                         outbound.key_down(id, key).await.unwrap();
                     }
-                    DeviceStateUpdate::ButtonUp(key) if key < key_count => {
+                    DeviceStateUpdate::ButtonUp(key) => {
                         outbound.key_up(id, key).await.unwrap();
                     }
-                    DeviceStateUpdate::ButtonDown(_) | DeviceStateUpdate::ButtonUp(_) => {}
                     DeviceStateUpdate::EncoderDown(encoder) => {
                         outbound.encoder_down(id, encoder).await.unwrap();
                     }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,6 +1,8 @@
 use mirajazz::{error::MirajazzError, types::DeviceInput};
 
-use crate::mappings::{ENCODER_COUNT, KEY_COUNT};
+// Maximum parser capacity — actual device key/encoder counts are enforced at the device level
+const MAX_KEY_COUNT: usize = 9;
+const MAX_ENCODER_COUNT: usize = 3;
 
 pub fn process_input(input: u8, state: u8) -> Result<DeviceInput, MirajazzError> {
     log::info!("Processing input: {}, {}", input, state);
@@ -16,7 +18,7 @@ pub fn process_input(input: u8, state: u8) -> Result<DeviceInput, MirajazzError>
 fn read_button_states(states: &[u8]) -> Vec<bool> {
     let mut bools = vec![];
 
-    for i in 0..KEY_COUNT {
+    for i in 0..MAX_KEY_COUNT {
         bools.push(states[i + 1] != 0);
     }
 
@@ -25,7 +27,7 @@ fn read_button_states(states: &[u8]) -> Vec<bool> {
 
 fn read_button_press(input: u8, state: u8) -> Result<DeviceInput, MirajazzError> {
     let mut button_states = vec![0x01];
-    button_states.extend(vec![0u8; KEY_COUNT + 1]);
+    button_states.extend(vec![0u8; MAX_KEY_COUNT + 1]);
 
     if input == 0 {
         return Ok(DeviceInput::ButtonStateChange(read_button_states(
@@ -51,7 +53,7 @@ fn read_button_press(input: u8, state: u8) -> Result<DeviceInput, MirajazzError>
 }
 
 fn read_encoder_value(input: u8) -> Result<DeviceInput, MirajazzError> {
-    let mut encoder_values = vec![0i8; ENCODER_COUNT];
+    let mut encoder_values = vec![0i8; MAX_ENCODER_COUNT];
 
     let (encoder, value): (usize, i8) = match input {
         // Left encoder
@@ -71,7 +73,7 @@ fn read_encoder_value(input: u8) -> Result<DeviceInput, MirajazzError> {
 }
 
 fn read_encoder_press(input: u8, state: u8) -> Result<DeviceInput, MirajazzError> {
-    let mut encoder_states = vec![false; ENCODER_COUNT];
+    let mut encoder_states = vec![false; MAX_ENCODER_COUNT];
 
     let encoder: usize = match input {
         0x33 => 0, // Left encoder

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -6,10 +6,6 @@ use mirajazz::{
 // Must be unique between all the plugins, 2 characters long and match `DeviceNamespace` field in `manifest.json`
 pub const DEVICE_NAMESPACE: &str = "n3";
 
-pub const ROW_COUNT: usize = 3;
-pub const COL_COUNT: usize = 3;
-pub const KEY_COUNT: usize = 9;
-pub const ENCODER_COUNT: usize = 3;
 
 #[derive(Debug, Clone)]
 pub enum Kind {
@@ -152,22 +148,52 @@ impl Kind {
         }
     }
 
-    pub fn image_format(&self) -> ImageFormat {
-        if self.protocol_version() == 3 {
-            return ImageFormat {
-                mode: ImageMode::JPEG,
-                size: (60, 60),
-                rotation: ImageRotation::Rot90,
-                mirror: ImageMirroring::None,
-            };
+    /// Number of rows of screen buttons on the device.
+    /// Override for devices with fewer rows (e.g. MSD-TWO has 2 rows instead of 3).
+    pub fn row_count(&self) -> usize {
+        match self {
+            Self::MSDTWO => 2,
+            _ => 3,
         }
+    }
 
-        return ImageFormat {
+    /// Number of columns of screen buttons on the device.
+    pub fn col_count(&self) -> usize {
+        match self {
+            _ => 3,
+        }
+    }
+
+    /// Total number of screen buttons exposed to OpenDeck.
+    /// Derived from row_count * col_count — non-screen buttons (e.g. navigation keys)
+    /// are excluded here and filtered at the device event level.
+    pub fn key_count(&self) -> usize {
+        self.row_count() * self.col_count()
+    }
+
+    /// Number of rotary encoders on the device.
+    pub fn encoder_count(&self) -> usize {
+        match self {
+            _ => 3,
+        }
+    }
+
+    /// Returns the image format configuration for the device's LCD screens.
+    /// Override for devices that need different rotation or size than their
+    /// protocol version default (e.g. MSD-TWO uses protocol v2 but needs Rot90).
+    pub fn image_format(&self) -> ImageFormat {
+        let rotation = match self {
+            Self::MSDTWO => ImageRotation::Rot90,
+            _ if self.protocol_version() == 3 => ImageRotation::Rot90,
+            _ => ImageRotation::Rot0,
+        };
+
+        ImageFormat {
             mode: ImageMode::JPEG,
             size: (60, 60),
-            rotation: ImageRotation::Rot0,
+            rotation,
             mirror: ImageMirroring::None,
-        };
+        }
     }
 }
 

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -148,30 +148,22 @@ impl Kind {
         }
     }
 
-    /// Number of rows of screen buttons on the device.
-    /// Override for devices with fewer rows (e.g. MSD-TWO has 2 rows instead of 3).
     pub fn row_count(&self) -> usize {
         match self {
-            Self::MSDTWO => 2,
             _ => 3,
         }
     }
 
-    /// Number of columns of screen buttons on the device.
     pub fn col_count(&self) -> usize {
         match self {
             _ => 3,
         }
     }
 
-    /// Total number of screen buttons exposed to OpenDeck.
-    /// Derived from row_count * col_count — non-screen buttons (e.g. navigation keys)
-    /// are excluded here and filtered at the device event level.
     pub fn key_count(&self) -> usize {
         self.row_count() * self.col_count()
     }
 
-    /// Number of rotary encoders on the device.
     pub fn encoder_count(&self) -> usize {
         match self {
             _ => 3,


### PR DESCRIPTION
Replace hardcoded global layout constants (3x3, 9 keys, 3 encoders) with per-device methods on `Kind`, allowing devices with different physical layouts to correctly report their dimensions to OpenDeck.

For the Mars Gaming MSD-TWO:
- Apply `Rot90` image rotation to fix sideways icons on the LCD screens

Adding support for new devices with different layouts only requires overriding the relevant method on `Kind`.

Tested on macOS with a physical MSD-TWO device.

Closes #22
Relates to #10, #2