### PR TITLE
Correct image_format for protocol_version==3 mappings.rs

### DIFF
--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -162,7 +162,7 @@ impl Kind {
         if self.protocol_version() == 3 {
             return ImageFormat {
                 mode: ImageMode::JPEG,
-                size: (60, 60),
+                size: (64, 64),
                 rotation: ImageRotation::Rot90,
                 mirror: ImageMirroring::None,
             };


### PR DESCRIPTION
Image size for protocol_version 3 which is used by Ref. 2 products is 64x64, not 60x60

See also:
https://github.com/Aiacos/ajazz-control-center/blob/develop/docs/protocols/streamdeck/akp03.md

Rebuilding with 64x64 correctly fixed an image glitch where the outer top ane right borders were repeated 4 times outwards instead of showing actual image data. Confirmed on AKP03E rev. 2 

Thanks!