### PR TITLE
fix(watcher): recover devices orphaned by hotplug-stream panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 use device::{handle_error, handle_set_image};
 use mirajazz::device::Device;
 use openaction::*;
-use std::{collections::HashMap, process::exit, sync::LazyLock};
+use std::{
+    collections::{HashMap, HashSet},
+    process::exit,
+    sync::LazyLock,
+};
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use watcher::watcher_task;
@@ -19,6 +23,17 @@ pub static DEVICES: LazyLock<RwLock<HashMap<String, Device>>> =
 pub static TOKENS: LazyLock<RwLock<HashMap<String, CancellationToken>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 pub static TRACKER: LazyLock<Mutex<TaskTracker>> = LazyLock::new(|| Mutex::new(TaskTracker::new()));
+/// Device ids that currently have a managing [`device::device_task`].
+///
+/// Single source of truth for "this device is already being managed", shared by the
+/// hotplug event stream and the periodic rescan so they cannot double-spawn a device.
+/// Cleared via an RAII guard (`watcher::SpawnGuard`) when the managing task exits on
+/// *any* path (normal return, panic, or mid-flight drop), so recovery is robust.
+///
+/// Uses a `std::sync::Mutex` because the guard releases it from a synchronous `Drop`
+/// and every critical section is non-`async`.
+pub static SPAWNING: LazyLock<std::sync::Mutex<HashSet<String>>> =
+    LazyLock::new(|| std::sync::Mutex::new(HashSet::new()));
 
 struct GlobalEventHandler {}
 impl openaction::GlobalEventHandler for GlobalEventHandler {

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use futures_lite::StreamExt;
 use mirajazz::{
     device::{DeviceWatcher, list_devices},
@@ -5,13 +7,26 @@ use mirajazz::{
     types::{DeviceLifecycleEvent, HidDeviceInfo},
 };
 use openaction::OUTBOUND_EVENT_MANAGER;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    DEVICES, TOKENS, TRACKER,
+    DEVICES, SPAWNING, TOKENS, TRACKER,
     device::device_task,
     mappings::{CandidateDevice, DEVICE_NAMESPACE, Kind, QUERIES},
 };
+
+/// How often the watcher re-scans for devices that are connected at the OS level but
+/// not currently managed. This is the self-healing path: it recovers devices orphaned
+/// by a missed hotplug event or by a panic in the event stream (see `spawn_event_stream`).
+const RESCAN_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Floor delay before recreating the event stream after it ends.
+const STREAM_RESTART_DELAY: Duration = Duration::from_secs(1);
+
+/// Ceiling for the event-stream restart backoff.
+const MAX_RESTART_DELAY: Duration = Duration::from_secs(30);
 
 fn serial_to_id(serial: &String) -> String {
     format!("{}-{}", DEVICE_NAMESPACE, serial)
@@ -26,7 +41,7 @@ fn device_info_to_candidate(dev: HidDeviceInfo) -> Option<CandidateDevice> {
 
 /// Returns devices that matches known pid/vid pairs
 async fn get_candidates() -> Result<Vec<CandidateDevice>, MirajazzError> {
-    log::info!("Looking for candidate devices");
+    log::debug!("Looking for candidate devices");
 
     let mut candidates: Vec<CandidateDevice> = Vec::new();
 
@@ -41,82 +56,191 @@ async fn get_candidates() -> Result<Vec<CandidateDevice>, MirajazzError> {
     Ok(candidates)
 }
 
-pub async fn watcher_task(token: CancellationToken) -> Result<(), MirajazzError> {
-    let tracker = TRACKER.lock().await.clone();
+/// RAII guard that releases a device's entry in [`SPAWNING`] when dropped.
+///
+/// Owned by the managing `device_task`'s task, so the entry is released on *every* exit
+/// path: normal return, a panic inside `device_task`, or the future being dropped
+/// mid-flight (e.g. runtime shutdown). This is what keeps recovery robust even if
+/// `device_task` panics — without it, a panicked task would leak its id in `SPAWNING`
+/// forever and the device could never be re-spawned.
+struct SpawnGuard {
+    id: String,
+}
 
-    // Scans for connected devices that (possibly) we can use
-    let candidates = get_candidates().await?;
+impl Drop for SpawnGuard {
+    fn drop(&mut self) {
+        SPAWNING.lock().unwrap().remove(&self.id);
+    }
+}
 
-    log::info!("Looking for connected devices");
-
-    for candidate in candidates {
-        log::info!("New candidate {:#?}", candidate);
-
-        let token = CancellationToken::new();
-
-        TOKENS
-            .write()
-            .await
-            .insert(candidate.id.clone(), token.clone());
-
-        tracker.spawn(device_task(candidate, token));
+/// Spawns a [`device_task`] for `candidate` unless one is already managing it.
+///
+/// Returns `true` if a new task was spawned.
+///
+/// This is the single idempotent entry point for starting device management. Both the
+/// hotplug event stream and the periodic rescan go through here, so they can never
+/// double-spawn the same physical device. The `SPAWNING` set is cleared by the task
+/// itself when it exits (success or failure), so recovery from a missed event or a
+/// watcher panic is automatic.
+async fn spawn_device_if_unmanaged(candidate: CandidateDevice) -> bool {
+    {
+        let mut spawning = SPAWNING.lock().unwrap();
+        if spawning.contains(&candidate.id) {
+            return false;
+        }
+        spawning.insert(candidate.id.clone());
     }
 
-    let mut watcher = DeviceWatcher::new();
-    let mut watcher_stream = watcher.watch(&QUERIES).await?;
+    log::info!("Spawning device task for {:?}", candidate);
 
-    log::info!("Watcher is ready");
+    let token = CancellationToken::new();
+    TOKENS
+        .write()
+        .await
+        .insert(candidate.id.clone(), token.clone());
 
-    loop {
-        let ev = tokio::select! {
-            v = watcher_stream.next() => v,
-            _ = token.cancelled() => None
+    let tracker = TRACKER.lock().await.clone();
+    tracker.spawn(async move {
+        let _guard = SpawnGuard {
+            id: candidate.id.clone(),
         };
+        device_task(candidate, token).await;
+    });
 
-        if let Some(ev) = ev {
-            log::info!("New device event: {:?}", ev);
+    true
+}
 
-            match ev {
-                DeviceLifecycleEvent::Connected(info) => {
-                    if let Some(candidate) = device_info_to_candidate(info) {
-                        // Don't add existing device again
-                        if DEVICES.read().await.contains_key(&candidate.id) {
-                            continue;
-                        }
+/// Re-scans the OS for supported devices and spawns tasks for any present but unmanaged
+/// ones. Self-healing path: recovers devices orphaned by a missed hotplug event or an
+/// event-stream panic.
+async fn rescan_and_spawn() -> Result<(), MirajazzError> {
+    for candidate in get_candidates().await? {
+        spawn_device_if_unmanaged(candidate).await;
+    }
 
-                        let token = CancellationToken::new();
+    Ok(())
+}
 
-                        TOKENS
-                            .write()
-                            .await
-                            .insert(candidate.id.clone(), token.clone());
+/// Handles a single hotplug lifecycle event from mirajazz's [`DeviceWatcher`].
+async fn handle_lifecycle_event(ev: DeviceLifecycleEvent) {
+    log::info!("New device event: {:?}", ev);
 
-                        log::debug!("Spawning task for new device: {:?}", candidate);
-                        tracker.spawn(device_task(candidate, token));
-                        log::debug!("Spawned");
-                    }
-                }
-                DeviceLifecycleEvent::Disconnected(info) => {
-                    let id = serial_to_id(&info.serial_number.unwrap());
-
-                    if let Some(token) = TOKENS.write().await.remove(&id) {
-                        log::info!("Sending cancel request for {}", id);
-                        token.cancel();
-                    }
-
-                    DEVICES.write().await.remove(&id);
-
-                    if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
-                        outbound.deregister_device(id.clone()).await.ok();
-                    }
-
-                    log::info!("Disconnected device {}", id);
-                }
+    match ev {
+        DeviceLifecycleEvent::Connected(info) => {
+            if let Some(candidate) = device_info_to_candidate(info) {
+                spawn_device_if_unmanaged(candidate).await;
             }
-        } else {
-            log::info!("Watcher is shutting down");
+        }
+        DeviceLifecycleEvent::Disconnected(info) => {
+            let id = serial_to_id(&info.serial_number.unwrap());
 
-            break Ok(());
+            if let Some(token) = TOKENS.write().await.remove(&id) {
+                log::info!("Sending cancel request for {}", id);
+                token.cancel();
+            }
+
+            DEVICES.write().await.remove(&id);
+
+            if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
+                outbound.deregister_device(id.clone()).await.ok();
+            }
+
+            log::info!("Disconnected device {}", id);
         }
     }
+}
+
+/// Spawns a task that drives the mirajazz hotplug event stream.
+///
+/// `mirajazz` 0.16.2's `DeviceWatcher::watch` can panic inside its `Connected` handler
+/// (`query_devices(...).await.unwrap()` at `device.rs:139`) when a device is reconnected
+/// faster than `async-hid` can fully re-query it. That panic ends this task; the caller
+/// supervises the returned [`JoinHandle`] and recreates the stream, so hotplug detection
+/// recovers instead of going silent (which previously orphaned the device until restart).
+fn spawn_event_stream() -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut watcher = DeviceWatcher::new();
+
+        let mut stream = match watcher.watch(&QUERIES).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                log::warn!("DeviceWatcher::watch failed: {err}");
+                return;
+            }
+        };
+
+        log::info!("Device event stream is ready");
+
+        while let Some(ev) = stream.next().await {
+            handle_lifecycle_event(ev).await;
+        }
+
+        log::info!("Device event stream ended");
+    })
+}
+
+pub async fn watcher_task(token: CancellationToken) -> Result<(), MirajazzError> {
+    log::info!("Watcher is starting");
+
+    // Initial enumeration of already-connected devices. A failure here (e.g. the HID
+    // backend not yet ready at plugin start) must not abort the watcher: the periodic
+    // rescan below will retry shortly.
+    if let Err(err) = rescan_and_spawn().await {
+        log::warn!("Initial device rescan failed: {err}");
+    }
+
+    let mut poll = tokio::time::interval(RESCAN_INTERVAL);
+    poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // Discard the immediate first tick; we just enumerated above.
+    poll.tick().await;
+
+    // Supervised event stream: recreated if it ends or panics (see `spawn_event_stream`).
+    let mut event_task = spawn_event_stream();
+    let mut spawned_at = Instant::now();
+    let mut backoff = STREAM_RESTART_DELAY;
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => {
+                event_task.abort();
+                break;
+            }
+            _ = poll.tick() => {
+                if let Err(err) = rescan_and_spawn().await {
+                    log::warn!("Periodic device rescan failed: {err}");
+                }
+            }
+            joined = &mut event_task => {
+                match joined {
+                    Ok(()) => log::info!("Device event stream ended, restarting"),
+                    Err(err) if err.is_panic() => {
+                        log::error!("Device event stream panicked, restarting: {err}");
+                    }
+                    Err(err) => log::warn!("Device event stream task failed, restarting: {err}"),
+                }
+
+                // If the stream outlived the current backoff, treat it as relatively
+                // healthy and reset the delay; otherwise grow it to avoid flooding the
+                // log if the watcher keeps failing.
+                if spawned_at.elapsed() >= backoff {
+                    backoff = STREAM_RESTART_DELAY;
+                } else {
+                    backoff = (backoff * 2).min(MAX_RESTART_DELAY);
+                }
+
+                // Race the restart delay against cancellation so shutdown stays prompt.
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+
+                spawned_at = Instant::now();
+                event_task = spawn_event_stream();
+            }
+        }
+    }
+
+    log::info!("Watcher is shutting down");
+
+    Ok(())
 }


### PR DESCRIPTION
## Problem

Unplugging and reconnecting a device (especially a rapid reconnect) orphans it: the LCD keys go black and only restarting OpenDeck recovers it. Reproduced with a Soomfon Stream Controller SE (`1500:3001`, protocol v3).

## Root cause

Upstream, in `mirajazz` 0.16.2. `DeviceWatcher::watch()`'s `Connected` handler does:

```rust
async_hid::DeviceEvent::Connected(device_id) => {
    let device = HidBackend::default()
        .query_devices(&device_id)
        .await
        .unwrap()   // <-- device.rs:139
```

On a rapid reconnect, `async-hid` can fail to fully re-query the device that just reappeared, so `query_devices()` returns `Err` and the `.unwrap()` **panics**. That panic kills the entire watcher-stream task, after which **no connect/disconnect events are ever processed again** — so the replugged device is never re-registered and sits dark until OpenDeck is restarted.

The device teardown path itself is fine (`shutdown`/`reset`/`flush` all use `?` and return `Result`; there is no `Drop` in `mirajazz`). The only panic in normal operation is this one.

## Fix

The plugin cannot edit the `mirajazz` crate, so this makes hotplug detection resilient at the plugin level (`src/watcher.rs`, `src/main.rs`):

1. **Supervised event stream.** The `mirajazz` stream is driven in a separately-spawned task whose `JoinHandle` is supervised; if it ends or panics, a fresh `DeviceWatcher` is recreated after a backoff-bounded delay (1s → 30s, reset when a run outlives the current backoff).
2. **Self-healing rescan.** A 3s periodic `list_devices()` rescan spawns a `device_task` for any device present at the OS level but not currently managed — recovering orphans even when the event stream is dead. (Verified `async-hid`'s Linux netlink socket closes on drop, so repeatedly recreating the watcher does not leak fds/monitors.)
3. **Idempotent spawning.** A `SPAWNING` set (released by an RAII `SpawnGuard` whose `Drop` runs on normal return, panic, and mid-flight drop) ensures the event stream and rescan can never double-spawn a device, and a panicking `device_task` can never leak its id (which would otherwise re-create the original orphan symptom).

Result: worst-case black-screen window after a replug is now ~3s (the rescan interval) instead of *until restart*.

## Notes / follow-ups

- The actual panic is in `mirajazz` `device.rs:139`. This PR is defense-in-depth and is worth keeping regardless (it also self-heals any *missed* hotplug event), but the `.unwrap()` should ideally be hardened upstream in `4ndv/mirajazz`. Happy to open that separately if useful.
- `info.serial_number.unwrap()` in the `Disconnected` handler is a pre-existing latent panic carried over verbatim; now additionally contained because a panic there only ends the supervised event task. Left unchanged to keep this diff focused.
- `cargo fmt --check` and `cargo clippy` are clean for the changed files (3 pre-existing clippy warnings in `device.rs`/`mappings.rs` untouched).

## Verification

`cargo build`, `cargo build --release --target x86_64-unknown-linux-gnu`, `cargo clippy`, `cargo fmt --check` all pass. Manual repro (unplug+replug) pending on my end; will report timings.