### PR TITLE
feat: add support for Mirabox N3 (6602:1000)

### DIFF
--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -41,6 +41,7 @@ pub const AKP03R_PID: u16 = 0x1003;
 pub const AKP03E_REV2_PID: u16 = 0x3002;
 pub const AKP03R_REV2_PID: u16 = 0x3003;
 pub const N3_PID: u16 = 0x1002;
+pub const N3_1000_PID: u16 = 0x1000;
 pub const N3EN_PID: u16 = 0x1003;
 pub const N3CN3_PID: u16 = 0x1002;
 pub const SOOMFON_SE_PID: u16 = 0x3001;
@@ -55,6 +56,7 @@ pub const AKP03R_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, AJAZZ_VID, AKP0
 pub const AKP03E_REV2_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, AJAZZ_VID, AKP03E_REV2_PID);
 pub const AKP03R_REV2_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, AJAZZ_VID, AKP03R_REV2_PID);
 pub const N3_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, N3_VID, N3_PID);
+pub const N3_1000_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, N3_VID, N3_1000_PID);
 pub const N3EN_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, MIRABOX_VID, N3EN_PID);
 pub const N3CN3_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, MIRABOX_VID, N3CN3_PID);
 pub const SOOMFON_SE_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, SOOMFON_VID, SOOMFON_SE_PID);
@@ -63,13 +65,14 @@ pub const TREASLIN_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, TREASLIN_VID,
 pub const REDRAGON_SS551_QUERY: DeviceQuery =
     DeviceQuery::new(65440, 1, REDRAGON_VID, REDRAGON_SS551_PID);
 
-pub const QUERIES: [DeviceQuery; 12] = [
+pub const QUERIES: [DeviceQuery; 13] = [
     AKP03_QUERY,
     AKP03E_QUERY,
     AKP03R_QUERY,
     AKP03E_REV2_QUERY,
     AKP03R_REV2_QUERY,
     N3_QUERY,
+    N3_1000_QUERY,
     N3EN_QUERY,
     N3CN3_QUERY,
     SOOMFON_SE_QUERY,
@@ -93,6 +96,7 @@ impl Kind {
 
             N3_VID => match pid {
                 N3_PID => Some(Kind::N3),
+                N3_1000_PID => Some(Kind::N3),
                 _ => None,
             },
 


### PR DESCRIPTION
## Summary

Add support for the Mirabox N3 with PID `0x1000` (sold as "HANVON UGEE CS06 for signing"), VID `0x6602`.

The existing `Kind::N3` was only matching PID `0x1002`. This unit reports VID `6602` / PID `1000` and behaves identically to the known N3: same event codes, protocol version 2, press-only button semantics (no state toggle). It is therefore mapped to `Kind::N3` via a new `N3_1000_QUERY`.

## Changes

- Add `N3_1000_PID` constant
- Add `N3_1000_QUERY` and include it in the device `QUERIES` list
- Map `N3_VID` + `N3_1000_PID` to `Kind::N3`

## Hardware validation

Tested by the device owner on OpenDeck 2.14.0 with this plugin built from this branch:

- Device detected as "Mirabox N3" (fw `V2.293N3.03.001`)
- All 9 buttons and 3 encoders functional
- LCD key images render correctly (60x60 JPEG)

One observation worth noting: this unit's input reports are 512 bytes, whereas protocol v2 is documented as 1024-byte reports. Decoding works correctly regardless — both report sizes are handled by the existing code — but mentioning it in case a stricter size check is ever added.
